### PR TITLE
Convert to new Path api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(os, core, old_io, old_path)]
+#![feature(os, core, old_io, old_path, env)]
 
 //! xdg-rs is a utility library to make conforming to the [XDG specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) easier.
 //!
@@ -10,6 +10,7 @@ use std::error::Error;
 use std::old_io as io;
 use std::old_io::fs::PathExtensions;
 use std::os;
+use std::env;
 
 /// Get the data home directory given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
@@ -19,7 +20,7 @@ pub fn get_data_home_from_env<F>(get_env_var: &F) -> Path where
     F: Fn(&str) -> Option<String>
 {
     getenv_path(get_env_var, "XDG_DATA_HOME")
-        .unwrap_or(os::homedir()
+        .unwrap_or(env::home_dir()
                        .unwrap()
                        .join(".local/share"))
 }
@@ -50,7 +51,7 @@ pub fn get_data_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
         None => default_paths
     };
 
-    os::split_paths(paths)
+    env::split_paths(&paths).collect()
 }
 
 /// Get the data directories.
@@ -68,7 +69,7 @@ pub fn get_config_home_from_env<F>(get_env_var: &F) -> Path where
     F: Fn(&str) -> Option<String>
 {
     getenv_path(get_env_var, "XDG_CONFIG_HOME")
-        .unwrap_or(os::homedir()
+        .unwrap_or(env::home_dir()
                        .unwrap()
                        .join(".config"))
 }
@@ -98,7 +99,7 @@ pub fn get_config_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
         None => default_paths
     };
 
-    os::split_paths(paths)
+    env::split_paths(&paths).collect()
 }
 
 /// Get the config directories.
@@ -116,7 +117,7 @@ pub fn get_cache_home_from_env<F>(get_env_var: &F) -> Path where
     F: Fn(&str) -> Option<String>
 {
     getenv_path(get_env_var, "XDG_CACHE_HOME")
-        .unwrap_or(os::homedir()
+        .unwrap_or(env::home_dir()
                        .unwrap()
                        .join(".cache"))
 }
@@ -185,6 +186,7 @@ fn getenv_path<F>(get_env_var: &F, env_var: &str) -> Option<Path> where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::env;
     use std::os;
 
     #[test]
@@ -194,15 +196,15 @@ mod tests {
 
         let f = |&: var: &str| { custom_env.get(var).map(|x| x.clone()) };
         assert!(super::get_data_home_from_env(&f)
-                == os::homedir().unwrap().join(".local/share"));
+                == env::home_dir().unwrap().join(".local/share"));
         assert!(super::get_data_dirs_from_env(&f)
                 == vec![Path::new("/usr/local/share"), Path::new("/usr/share")]);
         assert!(super::get_config_home_from_env(&f)
-                == os::homedir().unwrap().join(".config"));
+                == env::home_dir().unwrap().join(".config"));
         assert!(super::get_config_dirs_from_env(&f)
                 == vec![Path::new("/etc/xdg")]);
         assert!(super::get_cache_home_from_env(&f)
-                == os::homedir().unwrap().join(".cache"));
+                == env::home_dir().unwrap().join(".cache"));
         assert!(super::get_runtime_dir_from_env(&f)
                 == None);
     }
@@ -218,15 +220,15 @@ mod tests {
 
         let f = |&: var: &str| { custom_env.get(var).map(|x| x.clone()) };
         assert!(super::get_data_home_from_env(&f)
-                == os::homedir().unwrap().join(".local/share"));
+                == env::home_dir().unwrap().join(".local/share"));
         assert!(super::get_data_dirs_from_env(&f)
                 == vec![Path::new("/usr/local/share"), Path::new("/usr/share")]);
         assert!(super::get_config_home_from_env(&f)
-                == os::homedir().unwrap().join(".config"));
+                == env::home_dir().unwrap().join(".config"));
         assert!(super::get_config_dirs_from_env(&f)
                 == vec![Path::new("/etc/xdg")]);
         assert!(super::get_cache_home_from_env(&f)
-                == os::homedir().unwrap().join(".cache"));
+                == env::home_dir().unwrap().join(".cache"));
         assert!(super::get_runtime_dir_from_env(&f)
                 == None);
     }
@@ -245,11 +247,11 @@ mod tests {
         assert!(super::get_data_home_from_env(&f)
                 == custom_env.get("XDG_DATA_HOME").map(Path::new).unwrap());
         assert!(super::get_data_dirs_from_env(&f)
-                == (os::split_paths(&*custom_env["XDG_DATA_DIRS"])));
+                == (env::split_paths(&*custom_env["XDG_DATA_DIRS"]).collect::<Vec<Path>>()));
         assert!(super::get_config_home_from_env(&f)
                 == custom_env.get("XDG_CONFIG_HOME").map(Path::new).unwrap());
         assert!(super::get_config_dirs_from_env(&f)
-                == os::split_paths(&*custom_env["XDG_CONFIG_DIRS"]));
+                == env::split_paths(&*custom_env["XDG_CONFIG_DIRS"]).collect::<Vec<Path>>());
         assert!(super::get_cache_home_from_env(&f)
                 == custom_env.get("XDG_CACHE_HOME").map(Path::new).unwrap());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![feature(os, core, old_io, old_path, env)]
+#![cfg_attr(unix, feature(old_io, core, old_path))]
+#![feature(os, env, std_misc, path)]
 
 //! xdg-rs is a utility library to make conforming to the [XDG specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) easier.
 //!
@@ -6,43 +7,49 @@
 //! currently a more complete implementation of the specification. The APIs provided by
 //! ```rust-xdg``` and ```xdg-rs``` are different.
 
-use std::error::Error;
-use std::old_io as io;
-use std::old_io::fs::PathExtensions;
-use std::os;
+use std::path::PathBuf;
 use std::env;
+use std::ffi::{self, AsOsStr, OsString};
+
+fn home_dir() -> PathBuf {
+    PathBuf::new(env::home_dir().unwrap().as_os_str())
+}
+
+fn split_paths<P: ?Sized>(paths: &P) -> Vec<PathBuf>
+    where P: AsOsStr
+{
+    env::split_paths(paths).map(|x| PathBuf::new(x.as_os_str())).collect()
+}
 
 /// Get the data home directory given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
 ///
 /// If ```$XDG_DATA_HOME``` is not set, it returns ```$HOME/.local/share```.
-pub fn get_data_home_from_env<F>(get_env_var: &F) -> Path where
-    F: Fn(&str) -> Option<String>
+pub fn get_data_home_from_env<F>(get_env_var: &F) -> PathBuf where
+    F: Fn(&str) -> Option<OsString>
 {
     getenv_path(get_env_var, "XDG_DATA_HOME")
-        .unwrap_or(env::home_dir()
-                       .unwrap()
-                       .join(".local/share"))
+        .unwrap_or(home_dir().join(".local/share"))
 }
 
 /// Get the data home directory.
 ///
 /// If ```$XDG_DATA_HOME``` is not set, it returns ```$HOME/.local/share```.
-pub fn get_data_home() -> Path {
-    get_data_home_from_env(&os::getenv)
+pub fn get_data_home() -> PathBuf {
+    get_data_home_from_env(&env::var_os)
 }
 
 /// Get the default data directories given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
 ///
 /// If ```$XDG_DATA_DIRS``` is not set, it returns ```[/usr/local/share, /usr/share]```.
-pub fn get_data_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
-    F: Fn(&str) -> Option<String>
+pub fn get_data_dirs_from_env<F>(get_env_var: &F) -> Vec<PathBuf> where
+    F: Fn(&str) -> Option<OsString>
 {
-    let default_paths = "/usr/local/share:/usr/share".to_string();
+    let default_paths = "/usr/local/share:/usr/share".as_os_str().to_os_string();
     let paths = match (*get_env_var)("XDG_DATA_DIRS") {
         Some(paths) => {
-            if paths.len() > 0 {
+            if paths != ffi::OsString::from_str("") {
                 paths
             } else {
                 default_paths
@@ -51,46 +58,44 @@ pub fn get_data_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
         None => default_paths
     };
 
-    env::split_paths(&paths).collect()
+    split_paths(&paths)
 }
 
 /// Get the data directories.
 ///
 /// If ```$XDG_DATA_DIRS``` is not set, it returns ```[/usr/local/share, /usr/share]```.
-pub fn get_data_dirs() -> Vec<Path> {
-    get_data_dirs_from_env(&os::getenv)
+pub fn get_data_dirs() -> Vec<PathBuf> {
+    get_data_dirs_from_env(&env::var_os)
 }
 
 /// Get the config home directory given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
 ///
 /// If ```$XDG_CONFIG_HOME``` is not set, it returns ```$HOME/.config```.
-pub fn get_config_home_from_env<F>(get_env_var: &F) -> Path where
-    F: Fn(&str) -> Option<String>
+pub fn get_config_home_from_env<F>(get_env_var: &F) -> PathBuf where
+    F: Fn(&str) -> Option<OsString>
 {
     getenv_path(get_env_var, "XDG_CONFIG_HOME")
-        .unwrap_or(env::home_dir()
-                       .unwrap()
-                       .join(".config"))
+        .unwrap_or(home_dir().join(".config"))
 }
 /// Get the config home directory.
 ///
 /// If ```$XDG_CONFIG_HOME``` is not set, it returns ```$HOME/.config```.
-pub fn get_config_home() -> Path {
-    get_config_home_from_env(&os::getenv)
+pub fn get_config_home() -> PathBuf {
+    get_config_home_from_env(&env::var_os)
 }
 
 /// Get the default config directories given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
 ///
 /// If ```$XDG_CONFIG_DIRS``` is not set, it returns ```[/etc/xdg]```.
-pub fn get_config_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
-    F: Fn(&str) -> Option<String>
+pub fn get_config_dirs_from_env<F>(get_env_var: &F) -> Vec<PathBuf> where
+    F: Fn(&str) -> Option<OsString>
 {
-    let default_paths = "/etc/xdg".to_string();
+    let default_paths = "/etc/xdg".as_os_str().to_os_string();
     let paths = match (*get_env_var)("XDG_CONFIG_DIRS") {
         Some(paths) => {
-            if paths.len() > 0 {
+            if paths != OsString::from_str("") {
                 paths
             } else {
                 default_paths
@@ -99,48 +104,46 @@ pub fn get_config_dirs_from_env<F>(get_env_var: &F) -> Vec<Path> where
         None => default_paths
     };
 
-    env::split_paths(&paths).collect()
+    split_paths(&paths)
 }
 
 /// Get the config directories.
 ///
 /// If ```$XDG_CONFIG_DIRS``` is not set, it returns ```[/etc/xdg]```.
-pub fn get_config_dirs() -> Vec<Path> {
-    get_config_dirs_from_env(&os::getenv)
+pub fn get_config_dirs() -> Vec<PathBuf> {
+    get_config_dirs_from_env(&env::var_os)
 }
 
 /// Get the cache home directory given a closure that returns the the value of an environment variable.
 /// This method allows having a custom environment.
 ///
 /// If ```$XDG_CACHE_HOME``` is not set, it returns ```$HOME/.cache```.
-pub fn get_cache_home_from_env<F>(get_env_var: &F) -> Path where
-    F: Fn(&str) -> Option<String>
+pub fn get_cache_home_from_env<F>(get_env_var: &F) -> PathBuf where
+    F: Fn(&str) -> Option<OsString>
 {
     getenv_path(get_env_var, "XDG_CACHE_HOME")
-        .unwrap_or(env::home_dir()
-                       .unwrap()
-                       .join(".cache"))
+        .unwrap_or(home_dir().join(".cache"))
 }
 
 /// Get the cache home directory.
 ///
 /// If ```$XDG_CACHE_HOME``` is not set, it returns ```$HOME/.cache```.
-pub fn get_cache_home() -> Path {
-    get_cache_home_from_env(&os::getenv)
+pub fn get_cache_home() -> PathBuf {
+    get_cache_home_from_env(&env::var_os)
 }
 
 /// Get $XDG_RUNTIME_DIR if found in the environment.
 ///
 /// Returns None if ```$XDG_RUNTIME_PATH``` is not set, in which case it is up to the application
 /// to fallback to a location that conforms to the specification.
-pub fn get_runtime_dir_from_env<F>(get_env_var: &F) -> Option<Path> where
-    F: Fn(&str) -> Option<String>
+pub fn get_runtime_dir_from_env<F>(get_env_var: &F) -> Option<PathBuf> where
+    F: Fn(&str) -> Option<OsString>
 {
     getenv_path(get_env_var, "XDG_RUNTIME_DIR")
 }
 
-pub fn get_runtime_dir() -> Option<Path> {
-    getenv_path(&os::getenv, "XDG_RUNTIME_DIR")
+pub fn get_runtime_dir() -> Option<PathBuf> {
+    getenv_path(&env::var_os, "XDG_RUNTIME_DIR")
 }
 
 /// Check that the value set for ```$XDG_RUNTIME_DIR``` meets the requirements of the specification
@@ -150,10 +153,17 @@ pub fn get_runtime_dir() -> Option<Path> {
 /// >The lifetime of the directory MUST be bound to the user being logged in. It MUST be created when the user first logs in and if the user fully logs out the directory MUST be removed. If the user logs in more than once he should get pointed to the same directory, and it is mandatory that the directory continues to exist from his first login to his last logout on the system, and not removed in between. Files in the directory MUST not survive reboot or a full logout/login cycle.
 /// >
 /// >The directory MUST be on a local file system and not shared with any other system. The directory MUST by fully-featured by the standards of the operating system. More specifically, on Unix-like operating systems AF_UNIX sockets, symbolic links, hard links, proper permissions, file locking, sparse files, memory mapping, file change notifications, a reliable hard link count must be supported, and no restrictions on the file name character set should be imposed. Files in this directory MAY be subjected to periodic clean-up. To ensure that your files are not removed, they should have their access time timestamp modified at least once every 6 hours of monotonic time or the 'sticky' bit should be set on the file.
-pub fn test_runtime_dir(path: &Path) -> Result<(), String> {
-    match path.stat() {
+#[cfg(unix)]
+pub fn test_runtime_dir(path: &PathBuf) -> Result<(), String> {
+    use std::old_path;
+    use std::old_io;
+    use std::os::unix::prelude::OsStrExt;
+    use std::old_io::fs::PathExtensions;
+    use std::error::Error;
+    // FIXME: https://github.com/rust-lang/rfcs/issues/905
+    match old_path::Path::new(path.as_os_str().as_bytes()).stat() {
         Ok(stat) => {
-            if stat.perm.intersects(io::GROUP_RWX | io::OTHER_RWX) {
+            if stat.perm.intersects(old_io::GROUP_RWX | old_io::OTHER_RWX) {
                 Err("Incorrect permissions".to_string())
             } else {
                 Ok(())
@@ -164,14 +174,20 @@ pub fn test_runtime_dir(path: &Path) -> Result<(), String> {
     }
 }
 
-/// Get an environment variable's value as a Path.
-fn getenv_path<F>(get_env_var: &F, env_var: &str) -> Option<Path> where
-    F: Fn(&str) -> Option<String>
+#[cfg(not(unix))]
+pub fn test_runtime_dir(_path: &PathBuf) -> Result<(), String> {
+    Ok(())
+}
+
+
+/// Get an environment variable's value as a PathBuf.
+fn getenv_path<F>(get_env_var: &F, env_var: &str) -> Option<PathBuf> where
+    F: Fn(&str) -> Option<OsString>
 {
     let path = (*get_env_var)(env_var);
     match path {
         Some(path) => {
-            let path = Path::new(path);
+            let path = PathBuf::new(&path);
             if path.is_absolute() {
                 Some(path)
             } else {
@@ -187,24 +203,25 @@ fn getenv_path<F>(get_env_var: &F, env_var: &str) -> Option<Path> where
 mod tests {
     use std::collections::HashMap;
     use std::env;
-    use std::os;
+    use std::path::PathBuf;
+    use std::ffi::AsOsStr;
 
     #[test]
     fn test_env_with_no_xdg_vars() {
         let mut custom_env = HashMap::new();
-        custom_env.insert("dummy", "".to_string());
+        custom_env.insert("dummy", "");
 
-        let f = |&: var: &str| { custom_env.get(var).map(|x| x.clone()) };
+        let f = |&: var: &str| { custom_env.get(var).map(|x| x.as_os_str().to_os_string()) };
         assert!(super::get_data_home_from_env(&f)
-                == env::home_dir().unwrap().join(".local/share"));
+                == super::home_dir().join(".local/share"));
         assert!(super::get_data_dirs_from_env(&f)
-                == vec![Path::new("/usr/local/share"), Path::new("/usr/share")]);
+                == vec![PathBuf::new("/usr/local/share"), PathBuf::new("/usr/share")]);
         assert!(super::get_config_home_from_env(&f)
-                == env::home_dir().unwrap().join(".config"));
+                == super::home_dir().join(".config"));
         assert!(super::get_config_dirs_from_env(&f)
-                == vec![Path::new("/etc/xdg")]);
+                == vec![PathBuf::new("/etc/xdg")]);
         assert!(super::get_cache_home_from_env(&f)
-                == env::home_dir().unwrap().join(".cache"));
+                == super::home_dir().join(".cache"));
         assert!(super::get_runtime_dir_from_env(&f)
                 == None);
     }
@@ -212,47 +229,49 @@ mod tests {
     #[test]
     fn test_env_with_empty_xdg_vars() {
         let mut custom_env = HashMap::new();
-        custom_env.insert("XDG_DATA_HOME", "".to_string());
-        custom_env.insert("XDG_DATA_DIRS", "".to_string());
-        custom_env.insert("XDG_CONFIG_HOME", "".to_string());
-        custom_env.insert("XDG_CONFIG_DIRS", "".to_string());
-        custom_env.insert("XDG_CACHE_HOME", "".to_string());
+        custom_env.insert("XDG_DATA_HOME", "");
+        custom_env.insert("XDG_DATA_DIRS", "");
+        custom_env.insert("XDG_CONFIG_HOME", "");
+        custom_env.insert("XDG_CONFIG_DIRS", "");
+        custom_env.insert("XDG_CACHE_HOME", "");
 
-        let f = |&: var: &str| { custom_env.get(var).map(|x| x.clone()) };
+        let f = |&: var: &str| { custom_env.get(var).map(|x| x.as_os_str().to_os_string()) };
         assert!(super::get_data_home_from_env(&f)
-                == env::home_dir().unwrap().join(".local/share"));
+                == super::home_dir().join(".local/share"));
         assert!(super::get_data_dirs_from_env(&f)
-                == vec![Path::new("/usr/local/share"), Path::new("/usr/share")]);
+                == vec![PathBuf::new("/usr/local/share"), PathBuf::new("/usr/share")]);
         assert!(super::get_config_home_from_env(&f)
-                == env::home_dir().unwrap().join(".config"));
+                == super::home_dir().join(".config"));
         assert!(super::get_config_dirs_from_env(&f)
-                == vec![Path::new("/etc/xdg")]);
+                == vec![PathBuf::new("/etc/xdg")]);
         assert!(super::get_cache_home_from_env(&f)
-                == env::home_dir().unwrap().join(".cache"));
+                == super::home_dir().join(".cache"));
         assert!(super::get_runtime_dir_from_env(&f)
                 == None);
     }
 
     #[test]
     fn test_env_with_xdg_vars() {
-        let cwd = os::make_absolute(&Path::new(".")).unwrap();
+        let cwd = PathBuf::new(&env::current_dir().unwrap());
         let mut custom_env = HashMap::new();
-        custom_env.insert("XDG_DATA_HOME", format!("{}/user/data", cwd.display()));
-        custom_env.insert("XDG_DATA_DIRS", format!("{}/share/data:{}/local/data", cwd.display(), cwd.display()));
-        custom_env.insert("XDG_CONFIG_HOME", format!("{}/user/config", cwd.display()));
-        custom_env.insert("XDG_CONFIG_DIRS", format!("{}/config:{}/local/config", cwd.display(), cwd.display()));
-        custom_env.insert("XDG_CACHE_HOME", format!("{}/user/cache", cwd.display()));
+        custom_env.insert("XDG_DATA_HOME", cwd.join("user/data").as_os_str().to_os_string());
+        custom_env.insert("XDG_DATA_DIRS", env::join_paths(
+                vec![cwd.join("share/data"),cwd.join("local/data")].into_iter()).unwrap());
+        custom_env.insert("XDG_CONFIG_HOME", cwd.join("user/config").as_os_str().to_os_string());
+        custom_env.insert("XDG_CONFIG_DIRS", env::join_paths(
+                vec![cwd.join("config"), cwd.join("local/config")].into_iter()).unwrap());
+        custom_env.insert("XDG_CACHE_HOME", cwd.join("user/cache").as_os_str().to_os_string());
 
         let f = |&: var: &str| { custom_env.get(var).map(|x| x.clone()) };
         assert!(super::get_data_home_from_env(&f)
-                == custom_env.get("XDG_DATA_HOME").map(Path::new).unwrap());
+                == custom_env.get("XDG_DATA_HOME").map(PathBuf::new).unwrap());
         assert!(super::get_data_dirs_from_env(&f)
-                == (env::split_paths(&*custom_env["XDG_DATA_DIRS"]).collect::<Vec<Path>>()));
+                == (super::split_paths(&*custom_env["XDG_DATA_DIRS"])));
         assert!(super::get_config_home_from_env(&f)
-                == custom_env.get("XDG_CONFIG_HOME").map(Path::new).unwrap());
+                == custom_env.get("XDG_CONFIG_HOME").map(PathBuf::new).unwrap());
         assert!(super::get_config_dirs_from_env(&f)
-                == env::split_paths(&*custom_env["XDG_CONFIG_DIRS"]).collect::<Vec<Path>>());
+                == super::split_paths(&*custom_env["XDG_CONFIG_DIRS"]));
         assert!(super::get_cache_home_from_env(&f)
-                == custom_env.get("XDG_CACHE_HOME").map(Path::new).unwrap());
+                == custom_env.get("XDG_CACHE_HOME").map(PathBuf::new).unwrap());
     }
 }


### PR DESCRIPTION
The only remainder of the old path api usage is for:
- reading permissions (new path/io doesn't support that)
- grabbing current_dir, home_dir (which are immediately converted
  to new PathBufs).

I've added 2 helpers for home_dir (Path conversion) and split_paths
(return owned paths). They're not public, but I wouldn't object to them
being public if that made sense.

Note that the permissions checking is now a no-op on non-unix systems
due to a lack of an implementation (AFAIK, windows perms were a no-op
in std anyhow).
